### PR TITLE
feat: OpenAI Codex CLIのスキル登録に対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## プロジェクト概要
 
-インストール済みのCLIコマンドを検出し、Claude Codeのスキルとして `~/.claude/skills/<skill-name>/SKILL.md` に自動登録するBashスクリプト。
+インストール済みのCLIコマンドを検出し、Claude CodeおよびOpenAI Codex CLIのスキルとして自動登録するBashスクリプト。
+
+- Claude Code: `~/.claude/skills/<skill-name>/SKILL.md`
+- Codex CLI: `~/.codex/skills/<skill-name>/SKILL.md`（`allowed-tools`は自動除去）
 
 ## コマンド
 
 ```bash
-# スキルを登録
+# Claude Code と Codex の両方にスキルを登録
 ./register-skills.sh
+
+# Claude Code のみに登録
+./register-skills.sh --target claude
+
+# Codex のみに登録
+./register-skills.sh --target codex
 
 # ドライラン（確認のみ）
 ./register-skills.sh --dry-run
@@ -24,7 +33,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## アーキテクチャ
 
-- `register-skills.sh` - メインスクリプト。`commands.conf`を読み取り、各コマンドがインストール済みかチェックし、対応するテンプレートを `~/.claude/skills/` にコピー
+- `register-skills.sh` - メインスクリプト。`commands.conf`を読み取り、各コマンドがインストール済みかチェックし、対応するテンプレートを `~/.claude/skills/` および `~/.codex/skills/` にコピー（Codex向けは`allowed-tools`を自動除去）
 - `commands.conf` - 対象コマンドのリスト（1行1コマンド、`#`はコメント）
 - `templates/<command>.md` - 各コマンドのSKILL.mdテンプレート
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # cli-skill-toolbox
 
-インストール済みの便利CLIコマンド(gh/jq/yqなど)を検出して、Claude CodeのSkillsとして自動登録するためのBashスクリプトです。
+インストール済みの便利CLIコマンド(gh/jq/yqなど)を検出して、**Claude Code** および **OpenAI Codex CLI** のSkillsとして自動登録するためのBashスクリプトです。
 
-Claude Codeのスキルは `~/.claude/skills/<skill-name>/SKILL.md` に配置し、SKILL.md は YAML フロントマター (nameとdescription必須) + 指示本文 で構成します。
-また、`allowed-tools` を指定すると、スキル有効時に Claude が許可なしで使えるツールを絞れます。
+### Claude Code
+スキルは `~/.claude/skills/<skill-name>/SKILL.md` に配置されます。SKILL.md は YAML フロントマター (`name`, `description`, `allowed-tools`) + 指示本文で構成します。
+
+### Codex CLI
+スキルは `~/.codex/skills/<skill-name>/SKILL.md` に配置されます。SKILL.md は YAML フロントマター (`name`, `description`) + 指示本文で構成します。Codexでは `allowed-tools` は使用しないため、登録時に自動除去されます。
 
 ## インストール
 
@@ -18,8 +21,14 @@ chmod +x register-skills.sh
 ### 基本的な使い方
 
 ```bash
-# スキルを登録
+# Claude Code と Codex の両方にスキルを登録
 ./register-skills.sh
+
+# Claude Code のみに登録
+./register-skills.sh --target claude
+
+# Codex のみに登録
+./register-skills.sh --target codex
 
 # ドライラン（実際にファイルを作成せずに確認）
 ./register-skills.sh --dry-run
@@ -41,9 +50,9 @@ chmod +x register-skills.sh
 
 ```
 cli-skill-toolbox/
-├── register-skills.sh    # メインスクリプト
+├── register-skills.sh    # メインスクリプト（Claude Code / Codex 両対応）
 ├── commands.conf          # 対象コマンド設定ファイル
-├── templates/             # コマンド別テンプレート
+├── templates/             # コマンド別テンプレート（共通）
 │   ├── gh.md
 │   ├── jq.md
 │   ├── yq.md
@@ -54,6 +63,8 @@ cli-skill-toolbox/
 │   └── eza.md
 └── README.md
 ```
+
+テンプレートは Claude Code と Codex で共通です。Codex 向けの登録時には `allowed-tools` が自動的に除去されます。
 
 ## 設定ファイル (commands.conf)
 
@@ -75,7 +86,7 @@ yq
 1. `commands.conf` にコマンド名を追加
 2. `templates/<command>.md` にテンプレートファイルを作成
 
-テンプレートファイルの形式:
+テンプレートファイルの形式（Claude Code / Codex 共通）:
 
 ```markdown
 ---
@@ -90,7 +101,7 @@ allowed-tools:
 スキルの詳細な説明...
 ```
 
-> **Note:** `allowed-tools` は `Bash(コマンド名:*)` の形式で、そのコマンドのみに制限することを推奨します。
+> **Note:** `allowed-tools` は Claude Code 用のフィールドです。`Bash(コマンド名:*)` の形式で、そのコマンドのみに制限することを推奨します。Codex 向け登録時には自動的に除去されます。
 
 ## 対応コマンド
 

--- a/register-skills.sh
+++ b/register-skills.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# CLI Skill Toolbox - Claude Code スキル自動登録スクリプト
-# インストール済みのCLIコマンドを検出し、Claude Codeのスキルとして登録します
+# CLI Skill Toolbox - Claude Code / Codex スキル自動登録スクリプト
+# インストール済みのCLIコマンドを検出し、Claude Code・Codexのスキルとして登録します
 
 set -euo pipefail
 
@@ -16,7 +16,8 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="${SCRIPT_DIR}/commands.conf"
 TEMPLATES_DIR="${SCRIPT_DIR}/templates"
-SKILLS_DIR="${HOME}/.claude/skills"
+CLAUDE_SKILLS_DIR="${HOME}/.claude/skills"
+CODEX_SKILLS_DIR="${HOME}/.codex/skills"
 
 # ログ関数
 log_info() {
@@ -40,18 +41,21 @@ show_help() {
     cat << EOF
 Usage: $(basename "$0") [OPTIONS]
 
-インストール済みのCLIコマンドを検出し、Claude Codeのスキルとして登録します。
+インストール済みのCLIコマンドを検出し、Claude Code・Codexのスキルとして登録します。
 
 Options:
   -c, --config FILE    設定ファイルを指定 (デフォルト: commands.conf)
+  -t, --target TARGET  登録先を指定: claude, codex, all (デフォルト: all)
   -d, --dry-run        実際にファイルを作成せずに実行内容を表示
   -l, --list           登録可能なコマンドを一覧表示
   -h, --help           このヘルプを表示
 
 Examples:
-  $(basename "$0")              # デフォルト設定でスキルを登録
-  $(basename "$0") --dry-run    # ドライランで確認
-  $(basename "$0") --list       # 登録可能なコマンドを一覧表示
+  $(basename "$0")                  # 両方にスキルを登録
+  $(basename "$0") --target claude  # Claude Codeのみ
+  $(basename "$0") --target codex   # Codexのみ
+  $(basename "$0") --dry-run        # ドライランで確認
+  $(basename "$0") --list           # 登録可能なコマンドを一覧表示
 EOF
 }
 
@@ -71,12 +75,28 @@ read_commands() {
     grep -v '^#' "$CONFIG_FILE" | grep -v '^[[:space:]]*$' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
 
-# スキルを登録
+# テンプレートからallowed-toolsを除去してCodex用SKILL.mdを生成
+strip_allowed_tools() {
+    local input_file="$1"
+    # YAMLフロントマター内のallowed-tools行とその配列項目を除去
+    sed '/^allowed-tools:$/,/^[^ -]/{ /^allowed-tools:$/d; /^  - /d; }' "$input_file"
+}
+
+# スキルを登録（target: claude または codex）
 register_skill() {
     local cmd="$1"
     local dry_run="$2"
+    local target="$3"
     local template_file="${TEMPLATES_DIR}/${cmd}.md"
-    local skill_dir="${SKILLS_DIR}/${cmd}"
+
+    local skills_dir
+    if [[ "$target" == "codex" ]]; then
+        skills_dir="$CODEX_SKILLS_DIR"
+    else
+        skills_dir="$CLAUDE_SKILLS_DIR"
+    fi
+
+    local skill_dir="${skills_dir}/${cmd}"
     local skill_file="${skill_dir}/SKILL.md"
 
     # テンプレートが存在するか確認
@@ -86,29 +106,43 @@ register_skill() {
     fi
 
     if [[ "$dry_run" == "true" ]]; then
-        log_info "[DRY-RUN] スキルを登録: $cmd -> $skill_file"
+        log_info "[DRY-RUN] [$target] スキルを登録: $cmd -> $skill_file"
         return 0
     fi
 
     # スキルディレクトリを作成
     mkdir -p "$skill_dir"
 
-    # テンプレートをコピー（上書き）
-    cp "$template_file" "$skill_file"
+    if [[ "$target" == "codex" ]]; then
+        # Codex向け: allowed-toolsを除去してコピー
+        strip_allowed_tools "$template_file" > "$skill_file"
+    else
+        # Claude Code向け: そのままコピー
+        cp "$template_file" "$skill_file"
+    fi
 
-    log_success "スキルを登録しました: $cmd -> $skill_file"
+    log_success "[$target] スキルを登録しました: $cmd -> $skill_file"
 }
 
 # メイン処理
 main() {
     local dry_run="false"
     local list_only="false"
+    local target="all"
 
     # 引数をパース
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -c|--config)
                 CONFIG_FILE="$2"
+                shift 2
+                ;;
+            -t|--target)
+                target="$2"
+                if [[ "$target" != "claude" && "$target" != "codex" && "$target" != "all" ]]; then
+                    log_error "無効なターゲット: $target (claude, codex, all のいずれかを指定)"
+                    exit 1
+                fi
                 shift 2
                 ;;
             -d|--dry-run)
@@ -134,7 +168,13 @@ main() {
     log_info "CLI Skill Toolbox - スキル登録スクリプト"
     log_info "設定ファイル: $CONFIG_FILE"
     log_info "テンプレートディレクトリ: $TEMPLATES_DIR"
-    log_info "スキルディレクトリ: $SKILLS_DIR"
+    log_info "ターゲット: $target"
+    if [[ "$target" == "claude" || "$target" == "all" ]]; then
+        log_info "Claude Code スキルディレクトリ: $CLAUDE_SKILLS_DIR"
+    fi
+    if [[ "$target" == "codex" || "$target" == "all" ]]; then
+        log_info "Codex スキルディレクトリ: $CODEX_SKILLS_DIR"
+    fi
     echo
 
     # コマンドリストを取得
@@ -173,6 +213,15 @@ main() {
         exit 0
     fi
 
+    # 登録対象のターゲットリストを構築
+    local targets=()
+    if [[ "$target" == "claude" || "$target" == "all" ]]; then
+        targets+=("claude")
+    fi
+    if [[ "$target" == "codex" || "$target" == "all" ]]; then
+        targets+=("codex")
+    fi
+
     # スキルを登録
     for cmd in $commands; do
         if ! command_exists "$cmd"; then
@@ -181,11 +230,13 @@ main() {
             continue
         fi
 
-        if register_skill "$cmd" "$dry_run"; then
-            ((registered++))
-        else
-            ((skipped++))
-        fi
+        for t in "${targets[@]}"; do
+            if register_skill "$cmd" "$dry_run" "$t"; then
+                ((registered++))
+            else
+                ((skipped++))
+            fi
+        done
     done
 
     echo


### PR DESCRIPTION
## Summary

- `register-skills.sh` に `--target` オプション（`claude` / `codex` / `all`）を追加し、登録先を選択可能にした
- Codex向けにはテンプレートから `allowed-tools` フロントマターを自動除去して `~/.codex/skills/` に登録
- デフォルト（`--target all`）で Claude Code と Codex の両方に同時登録

## 変更内容

### register-skills.sh
- `SKILLS_DIR` を `CLAUDE_SKILLS_DIR` と `CODEX_SKILLS_DIR` に分離
- `strip_allowed_tools()` 関数を追加（Codex向けに `allowed-tools` を sed で除去）
- `register_skill()` に `target` 引数を追加（`claude` / `codex`）
- `-t, --target` オプションのパース・バリデーション追加
- ログ出力に `[claude]` / `[codex]` ラベルを表示

### README.md / CLAUDE.md
- Codex CLI 対応の説明を追加
- コマンド例に `--target` オプションを記載

## Codex スキル形式について

OpenAI Codex CLI のスキルは Claude Code と同じ `SKILL.md` 形式を使うが、以下の違いがある：

| | Claude Code | Codex CLI |
|---|---|---|
| 保存先 | `~/.claude/skills/` | `~/.codex/skills/` |
| フロントマター | `name`, `description`, `allowed-tools` | `name`, `description` のみ |

テンプレートを共通化し、Codex 向け登録時に `allowed-tools` を自動除去することで対応。

## Test plan

- [ ] `./register-skills.sh --dry-run` で両方のターゲットに登録されることを確認
- [ ] `./register-skills.sh --dry-run --target claude` で Claude Code のみに登録されることを確認
- [ ] `./register-skills.sh --dry-run --target codex` で Codex のみに登録されることを確認
- [ ] `./register-skills.sh --target codex` で実際に `~/.codex/skills/` に `allowed-tools` なしの SKILL.md が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)