### PR TITLE
クラウドCLI (aws / gcloud / az) の追加 (Issue #4)

### DIFF
--- a/commands.conf
+++ b/commands.conf
@@ -16,3 +16,8 @@ fd
 # その他便利ツール
 bat
 eza
+
+# クラウドCLI
+aws
+gcloud
+az

--- a/templates/aws.md
+++ b/templates/aws.md
@@ -1,0 +1,84 @@
+---
+name: aws
+description: AWS CLIを使用してAmazon Web Servicesのリソースを管理します。
+allowed-tools:
+  - Bash(aws:*)
+---
+
+# AWS CLI (aws) スキル
+
+AWS CLIはAmazon Web Servicesのリソースを管理するためのコマンドラインツールです。
+
+## 主な機能
+
+- EC2、S3、RDS等のAWSリソース管理
+- IAMユーザー・ロール・ポリシーの管理
+- Lambda、CloudWatch等のサーバーレスサービス操作
+- CloudFormation、Terraform等のIaCツールとの連携
+
+## 使用例
+
+```bash
+# S3バケットを一覧表示
+aws s3 ls
+
+# EC2インスタンスを一覧表示
+aws ec2 describe-instances
+
+# S3オブジェクトをコピー
+aws s3 cp file.txt s3://my-bucket/file.txt
+
+# Lambda関数を呼び出し
+aws lambda invoke --function-name my-function response.json
+
+# CloudWatchログを取得
+aws logs tail /aws/lambda/my-function --follow
+
+# 現在のユーザー情報を取得
+aws sts get-caller-identity
+```
+
+Bashツールを使用してawsコマンドを実行してください。
+
+## 注意事項
+
+以下の操作は変更・削除を伴うため、実行前にユーザーへ確認してください：
+
+- `aws ec2 terminate-instances` - EC2インスタンスの削除
+- `aws s3 rb` - S3バケットの削除
+- `aws rds delete-db-instance` - RDSインスタンスの削除
+- `aws iam delete-*` - IAMリソースの削除
+- `aws lambda delete-function` - Lambda関数の削除
+- `aws cloudformation delete-stack` - CloudFormationスタックの削除
+
+### 課金に影響する操作
+
+以下の操作は課金に影響する可能性があるため、確認してください：
+
+- EC2インスタンスの作成・起動
+- RDSインスタンスの作成
+- S3バケットの作成（特にバージョニング有効時）
+- Lambda関数の作成
+- その他のリソース作成操作
+
+実行前にリソースの料金体系を確認することを推奨します。
+
+### 認証情報の取り扱い
+
+- アクセスキー、シークレットキーの取り扱いに注意してください
+- 認証情報は環境変数や~/.aws/credentialsで管理することを推奨
+- MFAが有効な場合は、一時的な認証情報の使用を推奨
+
+### プロファイル確認
+
+**重要**: 実行前に現在のプロファイルとリージョンを確認してください：
+
+```bash
+# 現在の設定確認
+aws configure list
+
+# 呼び出し元身分確認
+aws sts get-caller-identity
+```
+
+本番アカウントでの操作は特に慎重に行ってください。

--- a/templates/az.md
+++ b/templates/az.md
@@ -1,0 +1,85 @@
+---
+name: az
+description: Azure CLIを使用してMicrosoft Azureのリソースを管理します。
+allowed-tools:
+  - Bash(az:*)
+---
+
+# Azure CLI (az) スキル
+
+Azure CLIはMicrosoft Azureのリソースを管理するためのコマンドラインツールです。
+
+## 主な機能
+
+- 仮想マシン、ストレージアカウント等のAzureリソース管理
+- Azure ADとポリシーの管理
+- Azure Functions、Container Instances等のサービス操作
+- AKS（Azure Kubernetes Service）の管理
+
+## 使用例
+
+```bash
+# 現在のサブスクリプションを設定
+az account set --subscription "My Subscription"
+
+# 仮想マシンを一覧表示
+az vm list
+
+# リソースグループを作成
+az group create --name my-group --location eastus
+
+# Azure Storageコンテナーを一覧表示
+az storage container list --account-name myaccount
+
+# Azure Functionをデプロイ
+az functionapp create --resource-group my-group --consumption-plan-location eastus \
+  --name my-function --storage-account mystorage --functions-version 4
+
+# 現在の設定を確認
+az account show
+```
+
+Bashツールを使用してazコマンドを実行してください。
+
+## 注意事項
+
+以下の操作は変更・削除を伴うため、実行前にユーザーへ確認してください：
+
+- `az vm delete` - 仮想マシンの削除
+- `az group delete` - リソースグループの削除
+- `az storage account delete` - ストレージアカウントの削除
+- `az sql server delete` - SQL Serverの削除
+- `az functionapp delete` - Function Appの削除
+- `az aks delete` - AKSクラスタの削除
+
+### 課金に影響する操作
+
+以下の操作は課金に影響する可能性があるため、確認してください：
+
+- 仮想マシンの作成・起動
+- SQL Database/SQL Serverの作成
+- Storage Accountの作成
+- App Service、Function Appの作成
+- その他のリソース作成操作
+
+実行前にリソースの料金体系を確認することを推奨します。
+
+### 認証情報の取り扱い
+
+- サービスプリンシパルの情報の取り扱いに注意してください
+- 認証は`az login`で管理することを推奨
+- サービスプリンシパルのシークレットは安全な場所に保管してください
+
+### サブスクリプション確認
+
+**重要**: 実行前に現在のサブスクリプションを確認してください：
+
+```bash
+# 現在のサブスクリプション確認
+az account show --query name -o tsv
+
+# すべてのサブスクリプションを一覧表示
+az account list --output table
+```
+
+本番サブスクリプションでの操作は特に慎重に行ってください。

--- a/templates/gcloud.md
+++ b/templates/gcloud.md
@@ -1,0 +1,84 @@
+---
+name: gcloud
+description: Google Cloud CLIを使用してGoogle Cloud Platformのリソースを管理します。
+allowed-tools:
+  - Bash(gcloud:*)
+---
+
+# Google Cloud CLI (gcloud) スキル
+
+Google Cloud CLIはGoogle Cloud Platformのリソースを管理するためのコマンドラインツールです。
+
+## 主な機能
+
+- Compute Engine、Cloud Storage等のGCPリソース管理
+- IAMとポリシーの管理
+- Cloud Functions、Cloud Run等のサーバーレスサービス操作
+- Kubernetes Engine（GKE）の管理
+
+## 使用例
+
+```bash
+# 現在のプロジェクトを設定
+gcloud config set project my-project
+
+# Compute Engineインスタンスを一覧表示
+gcloud compute instances list
+
+# Cloud Storageバケットを一覧表示
+gsutil ls
+
+# Cloud Functionsをデプロイ
+gcloud functions deploy my-function --runtime nodejs18
+
+# Cloud Runにデプロイ
+gcloud run deploy my-service --image gcr.io/my-project/my-image
+
+# 現在の構成を確認
+gcloud config list
+```
+
+Bashツールを使用してgcloudコマンドを実行してください。
+
+## 注意事項
+
+以下の操作は変更・削除を伴うため、実行前にユーザーへ確認してください：
+
+- `gcloud compute instances delete` - Compute Engineインスタンスの削除
+- `gcloud compute disks delete` - ディスクの削除
+- `gsutil rm` - Cloud Storageオブジェクトの削除
+- `gcloud sql instances delete` - Cloud SQLインスタンスの削除
+- `gcloud functions delete` - Cloud Functionsの削除
+- `gcloud container clusters delete` - GKEクラスタの削除
+
+### 課金に影響する操作
+
+以下の操作は課金に影響する可能性があるため、確認してください：
+
+- Compute Engineインスタンスの作成・起動
+- Cloud SQLインスタンスの作成
+- Cloud Storageバケットの作成
+- Cloud Functions、Cloud Runのデプロイ
+- その他のリソース作成操作
+
+実行前にリソースの料金体系を確認することを推奨します。
+
+### 認証情報の取り扱い
+
+- サービスアカウントキーの取り扱いに注意してください
+- 認証情報は`gcloud auth login`やADC（Application Default Credentials）で管理することを推奨
+- サービスアカウントキーファイルは安全な場所に保管してください
+
+### プロジェクト確認
+
+**重要**: 実行前に現在のプロジェクトを確認してください：
+
+```bash
+# 現在のプロジェクト確認
+gcloud config get-value project
+
+# 現在のアカウント確認
+gcloud auth list
+```
+
+本番プロジェクトでの操作は特に慎重に行ってください。


### PR DESCRIPTION
## 概要
主要クラウドプロバイダー（AWS、GCP、Azure）のCLIスキルを追加しました。

## 変更内容

### 新規テンプレート

#### templates/aws.md
- AWS CLIによるAmazon Web Servicesリソース管理
- EC2、S3、RDS、Lambda等の操作機能を記載
- リソース削除操作の警告
- 課金に影響する操作の警告
- 認証情報の取り扱いに関する注意事項
- プロファイル確認の推奨

#### templates/gcloud.md
- Google Cloud CLIによるGCPリソース管理
- Compute Engine、Cloud Storage、Cloud Functions等の操作機能を記載
- リソース削除操作の警告
- 課金に影響する操作の警告
- 認証情報の取り扱いに関する注意事項
- プロジェクト確認の推奨

#### templates/az.md
- Azure CLIによるMicrosoft Azureリソース管理
- 仮想マシン、Storage、Functions等の操作機能を記載
- リソース削除操作の警告
- 課金に影響する操作の警告
- 認証情報の取り扱いに関する注意事項
- サブスクリプション確認の推奨

### commands.conf
- `aws`, `gcloud`, `az` を追加

## 関連Issue
closes #4

## テスト計画
- [ ] テンプレートのYAMLフロントマターが正しいか確認
- [ ] `./register-skills.sh --list` で表示されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)