### PR TITLE
パッケージマネージャー (npm / yarn / pnpm) の追加 (Issue #5)

### DIFF
--- a/commands.conf
+++ b/commands.conf
@@ -16,3 +16,8 @@ fd
 # その他便利ツール
 bat
 eza
+
+# パッケージマネージャー
+npm
+yarn
+pnpm

--- a/templates/npm.md
+++ b/templates/npm.md
@@ -1,0 +1,67 @@
+---
+name: npm
+description: npmを使用してNode.jsパッケージの管理を行います。インストール、更新、公開等が可能です。
+allowed-tools:
+  - Bash(npm:*)
+---
+
+# npm スキル
+
+npmはNode Package Managerで、Node.jsのパッケージを管理するためのツールです。
+
+## 主な機能
+
+- パッケージのインストール・アンインストール
+- 依存関係の管理
+- スクリプトの実行
+- パッケージの公開・更新
+
+## 使用例
+
+```bash
+# パッケージをインストール
+npm install express
+
+# パッケージを開発依存としてインストール
+npm install --save-dev typescript
+
+# パッケージをグローバルにインストール
+npm install -g npm-check-updates
+
+# パッケージを更新
+npm update
+
+# 依存関係をチェック
+npm audit
+
+# スクリプトを実行
+npm run build
+
+# パッケージを公開
+npm publish
+```
+
+Bashツールを使用してnpmコマンドを実行してください。
+
+## 注意事項
+
+以下の操作は公開・削除を伴うため、実行前にユーザーへ確認してください：
+
+- `npm publish` - パッケージをnpmレジストリに公開
+- `npm unpublish` - 公開済みパッケージの削除（72時間以内のみ可能）
+- `npm deprecate` - パッケージを非推奨としてマーク
+- `npm owner remove` - パッケージの所有者から削除
+
+### グローバルインストール
+
+以下の操作はグローバル環境に変更を加えるため、確認してください：
+
+- `npm install -g` / `npm install --global` - グローバルへのインストール
+- `npm uninstall -g` / `npm uninstall --global` - グローバルからのアンインストール
+- `npm update -g` - グローバルパッケージの更新
+
+### その他の注意事項
+
+- `npm audit fix` でパッケージが更新される場合があります
+- `npm ci` はpackage-lock.jsonに基づいてクリーンインストールを行います
+- プライベートパッケージの場合、認証情報の取り扱いに注意してください

--- a/templates/pnpm.md
+++ b/templates/pnpm.md
@@ -1,0 +1,68 @@
+---
+name: pnpm
+description: pnpmを使用してNode.jsパッケージのディスク効率の良い管理を行います。
+allowed-tools:
+  - Bash(pnpm:*)
+---
+
+# pnpm スキル
+
+pnpmは高速でディスク容量を節約するNode.jsパッケージマネージャーです。
+
+## 主な機能
+
+- ハードリンクによる効率的なストレージ使用
+- 厳格な依存関係管理
+- ワークスペースのサポート
+- スクリプトの実行
+- パッケージの公開・更新
+
+## 使用例
+
+```bash
+# パッケージをインストール
+pnpm add express
+
+# パッケージを開発依存としてインストール
+pnpm add -D typescript
+
+# パッケージをグローバルにインストール
+pnpm add -g npm-check-updates
+
+# すべての依存関係をインストール
+pnpm install
+
+# パッケージを更新
+pnpm update
+
+# スクリプトを実行
+pnpm build
+
+# パッケージを公開
+pnpm publish
+```
+
+Bashツールを使用してpnpmコマンドを実行してください。
+
+## 注意事項
+
+以下の操作は公開・削除を伴うため、実行前にユーザーへ確認してください：
+
+- `pnpm publish` - パッケージをnpmレジストリに公開
+- `pnpm unpublish` - 公開済みパッケージの削除
+- `pnpm deprecate` - パッケージを非推奨としてマーク
+
+### グローバルインストール
+
+以下の操作はグローバル環境に変更を加えるため、確認してください：
+
+- `pnpm add -g` / `pnpm add --global` - グローバルへのインストール
+- `pnpm remove -g` / `pnpm remove --global` - グローバルからのアンインストール
+- `pnpm update -g` - グローバルパッケージの更新
+
+### その他の注意事項
+
+- `pnpm update` でパッケージが更新されます
+- `pnpm patch` でパッケージにパッチを適用可能です
+- pnpmはnode_modulesの構造が他のパッケージマネージャーと異なります
+- プライベートパッケージの場合、認証情報の取り扱いに注意してください

--- a/templates/yarn.md
+++ b/templates/yarn.md
@@ -1,0 +1,68 @@
+---
+name: yarn
+description: Yarnを使用してNode.jsパッケージの高速な管理を行います。
+allowed-tools:
+  - Bash(yarn:*)
+---
+
+# Yarn スキル
+
+Yarnは高速で安全なNode.jsパッケージマネージャーです。
+
+## 主な機能
+
+- パッケージの並列インストール
+- 依存関係の管理
+- ワークスペースのサポート
+- スクリプトの実行
+- パッケージの公開・更新
+
+## 使用例
+
+```bash
+# パッケージをインストール
+yarn add express
+
+# パッケージを開発依存としてインストール
+yarn add --dev typescript
+
+# パッケージをグローバルにインストール
+yarn global add npm-check-updates
+
+# すべての依存関係をインストール
+yarn install
+
+# パッケージを更新
+yarn upgrade
+
+# スクリプトを実行
+yarn build
+
+# パッケージを公開
+yarn publish
+```
+
+Bashツールを使用してyarnコマンドを実行してください。
+
+## 注意事項
+
+以下の操作は公開・削除を伴うため、実行前にユーザーへ確認してください：
+
+- `yarn publish` - パッケージをnpmレジストリに公開
+- `yarn npm unpublish` - 公開済みパッケージの削除
+- `yarn npm deprecate` - パッケージを非推奨としてマーク
+
+### グローバルインストール
+
+以下の操作はグローバル環境に変更を加えるため、確認してください：
+
+- `yarn global add` - グローバルへのインストール
+- `yarn global remove` - グローバルからのアンインストール
+- `yarn global upgrade` - グローバルパッケージの更新
+
+### その他の注意事項
+
+- `yarn upgrade` でパッケージが更新されます
+- `yarn upgrade-interactive` で対話的に更新可能です
+- Yarn 2以降（Berry）ではコマンド体系が異なる場合があります
+- プライベートパッケージの場合、認証情報の取り扱いに注意してください


### PR DESCRIPTION
## 概要
Node.jsパッケージマネージャー（npm、yarn、pnpm）のスキルを追加しました。

## 変更内容

### 新規テンプレート

#### templates/npm.md
- npm（Node Package Manager）のスキル
- パッケージのインストール、更新、スクリプト実行等の機能を記載
- `npm publish`, `npm unpublish` 等の公開操作の警告
- グローバルインストール（`-g`）の警告
- プライベートパッケージの認証情報に関する注意事項

#### templates/yarn.md
- Yarnパッケージマネージャーのスキル
- 並列インストール、ワークスペース等の機能を記載
- `yarn publish`, `yarn npm unpublish` 等の公開操作の警告
- グローバルインストールの警告
- Yarn 2以降（Berry）の違いに関する注意

#### templates/pnpm.md
- pnpmパッケージマネージャーのスキル
- ハードリンクによる効率的なストレージ使用等の機能を記載
- `pnpm publish`, `pnpm unpublish` 等の公開操作の警告
- グローバルインストールの警告
- node_modules構造の違いに関する注意

### commands.conf
- `npm`, `yarn`, `pnpm` を追加

## 関連Issue
closes #5

## テスト計画
- [ ] テンプレートのYAMLフロントマターが正しいか確認
- [ ] `./register-skills.sh --list` で表示されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)