### PR TITLE
アンインストール機能の追加 (Issue #6)

### DIFF
--- a/register-skills.sh
+++ b/register-skills.sh
@@ -48,6 +48,9 @@ Options:
   -t, --target TARGET  登録先を指定: claude, codex, all (デフォルト: all)
   -d, --dry-run        実際にファイルを作成せずに実行内容を表示
   -l, --list           登録可能なコマンドを一覧表示
+  -u, --uninstall CMD  指定したスキルを削除（複数指定可）
+  -U, --uninstall-all  登録済みの全スキルを削除
+  -y, --yes            確認プロンプトをスキップ（削除時）
   -h, --help           このヘルプを表示
 
 Examples:
@@ -56,6 +59,8 @@ Examples:
   $(basename "$0") --target codex   # Codexのみ
   $(basename "$0") --dry-run        # ドライランで確認
   $(basename "$0") --list           # 登録可能なコマンドを一覧表示
+  $(basename "$0") --uninstall gh jq  # 指定したスキルを削除
+  $(basename "$0") --uninstall-all   # 登録済みの全スキルを削除
 EOF
 }
 
@@ -124,11 +129,58 @@ register_skill() {
     log_success "[$target] スキルを登録しました: $cmd -> $skill_file"
 }
 
+# スキルをアンインストール
+uninstall_skill() {
+    local cmd="$1"
+    local dry_run="$2"
+    local target="$3"
+    local confirm="$4"
+
+    local skills_dir
+    if [[ "$target" == "codex" ]]; then
+        skills_dir="$CODEX_SKILLS_DIR"
+    else
+        skills_dir="$CLAUDE_SKILLS_DIR"
+    fi
+
+    local skill_dir="${skills_dir}/${cmd}"
+    local skill_file="${skill_dir}/SKILL.md"
+
+    # スキルが存在するか確認
+    if [[ ! -d "$skill_dir" ]]; then
+        log_warning "[$target] スキルが見つかりません: $cmd"
+        return 1
+    fi
+
+    if [[ "$dry_run" == "true" ]]; then
+        log_info "[DRY-RUN] [$target] スキルを削除: $skill_dir"
+        return 0
+    fi
+
+    # 確認プロンプト（-y オプションがない場合）
+    if [[ "$confirm" != "yes" ]]; then
+        echo -n "[$target] スキル '$cmd' を削除しますか？ [y/N] "
+        read -r response
+        if [[ ! "$response" =~ ^[Yy]$ ]]; then
+            log_info "[$target] スキルの削除をキャンセルしました: $cmd"
+            return 0
+        fi
+    fi
+
+    # スキルディレクトリを削除
+    rm -rf "$skill_dir"
+    log_success "[$target] スキルを削除しました: $cmd"
+}
+
 # メイン処理
 main() {
     local dry_run="false"
     local list_only="false"
     local target="all"
+    local uninstall_mode="false"
+    local uninstall_all_mode="false"
+    local confirm="no"
+    local uninstall_cmds=()
 
     # 引数をパース
     while [[ $# -gt 0 ]]; do
@@ -153,6 +205,23 @@ main() {
                 list_only="true"
                 shift
                 ;;
+            -u|--uninstall)
+                uninstall_mode="true"
+                shift
+                # 残りの引数がスキル名（オプションでない）
+                while [[ $# -gt 0 && ! "$1" =~ ^- ]]; do
+                    uninstall_cmds+=("$1")
+                    shift
+                done
+                ;;
+            -U|--uninstall-all)
+                uninstall_all_mode="true"
+                shift
+                ;;
+            -y|--yes)
+                confirm="yes"
+                shift
+                ;;
             -h|--help)
                 show_help
                 exit 0
@@ -175,6 +244,100 @@ main() {
     if [[ "$target" == "codex" || "$target" == "all" ]]; then
         log_info "Codex スキルディレクトリ: $CODEX_SKILLS_DIR"
     fi
+    echo
+
+    # アンインストールモード
+    if [[ "$uninstall_mode" == "true" ]]; then
+        if [[ ${#uninstall_cmds[@]} -eq 0 ]]; then
+            log_error "--uninstall オプションには削除するスキル名を指定してください"
+            exit 1
+        fi
+
+        log_info "スキルをアンインストールします: ${uninstall_cmds[*]}"
+        echo
+
+        local uninstalled=0
+        local not_installed=0
+
+        for cmd in "${uninstall_cmds[@]}"; do
+            for t in "${targets[@]}"; do
+                if uninstall_skill "$cmd" "$dry_run" "$t" "$confirm"; then
+                    ((uninstalled++))
+                else
+                    ((not_installed++))
+                fi
+            done
+        done
+
+        echo
+        log_info "=== 結果サマリー ==="
+        log_info "削除成功: $uninstalled"
+        log_info "見つからないスキル: $not_installed"
+
+        if [[ "$dry_run" == "true" ]]; then
+            echo
+            log_warning "これはドライランです。実際にファイルは削除されていません。"
+        fi
+        exit 0
+    fi
+
+    # 全スキルアンインストールモード
+    if [[ "$uninstall_all_mode" == "true" ]]; then
+        log_info "登録済みの全スキルをアンインストールします"
+        echo
+
+        # 全スキル削除の確認
+        if [[ "$confirm" != "yes" ]]; then
+            echo -n "本当に登録済みの全スキルを削除しますか？ [y/N] "
+            read -r response
+            if [[ ! "$response" =~ ^[Yy]$ ]]; then
+                log_info "全スキルの削除をキャンセルしました"
+                exit 0
+            fi
+        fi
+
+        local uninstalled=0
+
+        for t in "${targets[@]}"; do
+            local skills_dir
+            if [[ "$t" == "codex" ]]; then
+                skills_dir="$CODEX_SKILLS_DIR"
+            else
+                skills_dir="$CLAUDE_SKILLS_DIR"
+            fi
+
+            if [[ ! -d "$skills_dir" ]]; then
+                log_warning "[$t] スキルディレクトリが見つかりません: $skills_dir"
+                continue
+            fi
+
+            # ディレクトリ内の全スキルを削除
+            for skill_dir in "$skills_dir"/*; do
+                if [[ -d "$skill_dir" ]]; then
+                    local cmd_name=$(basename "$skill_dir")
+
+                    if [[ "$dry_run" == "true" ]]; then
+                        log_info "[DRY-RUN] [$t] スキルを削除: $skill_dir"
+                    else
+                        rm -rf "$skill_dir"
+                        log_success "[$t] スキルを削除しました: $cmd_name"
+                    fi
+                    ((uninstalled++))
+                fi
+            done
+        done
+
+        echo
+        log_info "=== 結果サマリー ==="
+        log_info "削除成功: $uninstalled"
+
+        if [[ "$dry_run" == "true" ]]; then
+            echo
+            log_warning "これはドライランです。実際にファイルは削除されていません。"
+        fi
+        exit 0
+    fi
+
     echo
 
     # コマンドリストを取得


### PR DESCRIPTION
## 概要
登録済みのスキルを削除するアンインストール機能を追加しました。

## 変更内容

### 新規オプション

- `--uninstall CMD [CMD ...]` - 指定したスキルを削除
- `--uninstall-all` - 登録済みの全スキルを削除
- `--yes` / `-y` - 確認プロンプトをスキップ

### 機能詳細

#### 個別スキルのアンインストール
```bash
# 特定のスキルを削除
./register-skills.sh --uninstall gh jq

# ドライランで確認
./register-skills.sh --uninstall gh --dry-run

# 確認をスキップして削除
./register-skills.sh --uninstall gh --yes
```

#### 全スキルのアンインストール
```bash
# 登録済みの全スキルを削除
./register-skills.sh --uninstall-all

# ドライランで確認
./register-skills.sh --uninstall-all --dry-run
```

#### ターゲット指定
```bash
# Claude Code のみから削除
./register-skills.sh --uninstall gh --target claude

# Codex のみから削除
./register-skills.sh --uninstall gh --target codex
```

### 実装詳細

- 削除前に確認プロンプトを表示（`--yes` でスキップ可能）
- `--dry-run` との組み合わせをサポート
- Claude Code と Codex の両方のターゲットに対応
- 複数のスキルを一度に削除可能

## 関連Issue
closes #6

## テスト計画
- [ ] `--uninstall` でスキルが正しく削除されるか確認
- [ ] `--uninstall-all` ですべてのスキルが削除されるか確認
- [ ] `--dry-run` で正しくプレビューされるか確認
- [ ] 確認プロンプトが正しく動作するか確認
- [ ] `--yes` で確認プロンプトがスキップされるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)